### PR TITLE
faster iterator + fixed found bugs

### DIFF
--- a/lib/src/vector.dart
+++ b/lib/src/vector.dart
@@ -193,7 +193,7 @@ abstract class BaseVectorImpl<E> extends PersistentVectorBase<E> {
       var node = newRoot;
       var parent = null;
       var idx = null;
-      for (var level = newLevel; level > _SHIFT; level -= SHIFT) {
+      for (var level = newLevel; level > _SHIFT; level -= _SHIFT) {
         parent = node;
         idx = (newTailOffset >> level) & _MASK;
         node._set(idx, _transientVNode(node._get(idx), owner));


### PR DESCRIPTION
pri implementovani noveho iteratora sa zistilo ze pri skracovani vektor-a sa pri zmene tail-u posledny node neodmaze hned z pamate co moze brzdit GC --> fixed
